### PR TITLE
[build] F: Feature switch for PIC support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ slab = { git = "https://github.com/nanvix/slab", branch = "releases/v0.0.4" }
 sys = { git = "https://github.com/nanvix/sys", branch = "releases/v1.3.0" }
 
 [features]
-default = ["qemu-pc"]
+default = ["qemu-pc", "enable-pic"]
 
 # Machine Types
 microvm = ["stdio"]
@@ -46,10 +46,12 @@ qemu-isapc = ["pc"]
 # Platform Features
 smp = []
 bios = []
+disable-pic = []
 cmos = []
 mboot = []
 pit = ["arch/pit"]
 stdio = []
+enable-pic = []
 
 # Logging Features
 trace = ["debug"]

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -72,12 +72,19 @@ pub fn init(
         platform::init(&mut ioports, &mut ioaddresses, memory_regions, mmio_regions, madt)?;
 
     // Initialize the interrupt manager.
+    #[cfg(feature = "enable-pic")]
     let intman: Option<InterruptManager> = match platform.arch.controller.take() {
         Some(controller) => Some(InterruptManager::new(controller)?),
         None => {
             warn!("no interrupt controller found");
             None
         },
+    };
+
+    #[cfg(not(feature = "enable-pic"))]
+    let intman: Option<InterruptManager> = {
+        info!("PIC support is disabled by feature flag");
+        None
     };
 
     // Initialize exception manager.


### PR DESCRIPTION
Regarding issue #432
   * Added feature to Cargo.TOML
   * Used conditional compilation for enabling PIC support. Executing
    `cargo build` will run without PIC support. To enable PIC support run `cargo build --features "enable_pic"`