### PR TITLE
[hal] E: Check lower memory regions are available

### DIFF
--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -68,13 +68,20 @@ pub fn init(
     memory_regions: &mut LinkedList<MemoryRegion<VirtualAddress>>,
     mmio_regions: &mut LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     madt: &Option<MadtInfo>,
+    mem_lower: Option<usize>,
 ) -> Result<Hal, Error> {
     info!("initializing hardware abstraction layer...");
 
     let mut ioports: IoPortAllocator = IoPortAllocator::new();
     let mut ioaddresses: IoMemoryAllocator = IoMemoryAllocator::new();
     let mut platform: Platform =
-        platform::init(&mut ioports, &mut ioaddresses, memory_regions, mmio_regions, madt)?;
+        platform::init(
+            &mut ioports, 
+            &mut ioaddresses, 
+            memory_regions, 
+            mmio_regions, 
+            madt,
+            mem_lower)?;
 
     // Initialize the interrupt manager.
     let intman: Option<InterruptManager> = match platform.arch.controller.take() {

--- a/src/hal/platform/bootinfo.rs
+++ b/src/hal/platform/bootinfo.rs
@@ -31,6 +31,8 @@ use ::alloc::collections::LinkedList;
 pub struct BootInfo {
     /// ACPI MADT information.
     pub madt: Option<MadtInfo>,
+    /// Lower memory size.
+    pub mem_lower: Option<usize>,
     /// General-purpose memory regions.
     pub memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
     /// Memory-mapped I/O regions.
@@ -52,6 +54,7 @@ impl BootInfo {
     /// # Parameters
     ///
     /// - `madt`: ACPI MADT information.
+    /// - `mem_lower`: Available Lower memory.
     /// - `memory_regions`: General-purpose memory regions.
     /// - `mmio_regions`: Memory-mapped I/O regions.
     /// - `kernel_modules`: Kernel modules.
@@ -62,12 +65,14 @@ impl BootInfo {
     ///
     pub fn new(
         madt: Option<MadtInfo>,
+        mem_lower: Option<usize>,
         memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
         mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
         kernel_modules: LinkedList<KernelModule>,
     ) -> Self {
         Self {
             madt,
+            mem_lower,
             memory_regions,
             mmio_regions,
             kernel_modules,

--- a/src/hal/platform/microvm.rs
+++ b/src/hal/platform/microvm.rs
@@ -202,7 +202,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
         kernel_modules.push_back(module);
     }
 
-    Ok(BootInfo::new(None, LinkedList::new(), LinkedList::new(), kernel_modules))
+    Ok(BootInfo::new(None, None, LinkedList::new(), LinkedList::new(), kernel_modules))
 }
 
 pub fn init(
@@ -211,6 +211,7 @@ pub fn init(
     _memory_regions: &mut LinkedList<MemoryRegion<VirtualAddress>>,
     _mmio_regions: &mut LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     madt: &Option<MadtInfo>,
+    _mem_lower: Option<usize>
 ) -> Result<Platform, Error> {
     Ok(Platform {
         arch: x86::init(ioports, ioaddresses, madt)?,

--- a/src/hal/platform/pc/mboot/acpi.rs
+++ b/src/hal/platform/pc/mboot/acpi.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::hal::platform::mboot::MbootTagType;
 use ::sys::error::{
     Error,
     ErrorCode,
@@ -22,7 +23,7 @@ use ::sys::error::{
 #[repr(C, align(8))]
 pub struct MbootAcpiTag {
     /// Type.
-    typ: u32,
+    typ: MbootTagType,
     /// Size.
     size: u32,
 }

--- a/src/hal/platform/pc/mboot/basic_mem_info.rs
+++ b/src/hal/platform/pc/mboot/basic_mem_info.rs
@@ -1,0 +1,131 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Multiboot Basic Mememory information Tag
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Multiboot Basic Memory information tag.
+///
+#[repr(C, align(8))]
+pub struct MbootBasicMeminfoTag {
+    /// Type.
+    typ: u32,
+    /// Size.
+    size: u32,
+}
+
+// `MbootBasicMeminfoTag` must be 16 bytes long. This must match the multiboot specification.
+sys::static_assert_size!(MbootBasicMeminfoTag, 8);
+
+// `MbootBasicMeminfoTag` must be 8-byte aligned. This must match the multiboot specification.
+sys::static_assert_alignment!(MbootBasicMeminfoTag, 8);
+
+impl core::fmt::Debug for MbootBasicMeminfoTag {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "MbootBasicMeminfoTag: typ={:?}, size={}", self.typ, self.size)
+    }
+}
+
+//==================================================================================================
+// Multiboot Basic Memory information
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Multiboot Basic Memory information
+///
+/// tag: Mboot Header
+///
+/// mem_lower: Size of available memory below 1MB starting from 0x0.
+///
+/// mem_upper: Size of the first contiguos memory region above 1MB.
+///
+pub struct MbootBasicMeminfo <'a>{
+    /// Tag.
+    tag: &'a MbootBasicMeminfoTag,
+    /// Lower memory size in kilobytes.
+    mem_lower: &'a usize,
+    /// Upper memory size in kilobytes.
+    mem_upper: &'a usize,
+}
+
+impl<'a> MbootBasicMeminfo<'a> {
+    pub unsafe fn from_raw(ptr: *const u8) -> Result<Self, Error> {
+        // Ensure that `ptr` is not null.
+        if ptr.is_null() {
+            let reason: &str = "null pointer";
+            error!("from_raw(): {:?}", reason);
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // Check if `ptr` is misaligned.
+        if !ptr.is_aligned_to(core::mem::align_of::<MbootBasicMeminfo>()) {
+            let reason: &str = "unaligned pointer";
+            error!("from_raw(): {:?}", reason);
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // Cast pointer to multiboot basic memory information tag.
+        let tag: &MbootBasicMeminfoTag = &*(ptr as *const MbootBasicMeminfoTag);
+
+        // Check if pointer arithmetic wraps around the address space.
+        if ptr.wrapping_add(tag.size as usize) < ptr {
+            let reason: &str = "pointer arithmetic wraps around the address space";
+            error!("from_raw(): {:?}", reason);
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        let ptr: *const u8 = ptr.add(core::mem::size_of::<MbootBasicMeminfoTag>());
+
+        // Cast pointer to lower memory address.
+        let mem_lower: &usize = &*(ptr as *const usize);
+
+        // Check if pointer arithmetic wraps around the address space.
+        if ptr.wrapping_add(core::mem::size_of::<u32>()) < ptr {
+            let reason: &str = "pointer arithmetic wraps around the address space";
+            error!("from_raw(): {:?}", reason);
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        let ptr: *const u8 = ptr.add(core::mem::size_of::<MbootBasicMeminfoTag>());
+
+        // Cast pointer to upper memory address.
+        let mem_upper: &usize = &*(ptr as *const usize);
+
+        Ok(Self { tag, mem_lower, mem_upper })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Displays information about the target multiboot Basic Memory information.
+    ///
+    pub fn display(&self) {
+        info!("{:?}", self.tag);
+        info!("Available Lower memory={:?}", self.mem_lower);
+        info!("Available Upper memory={:?}", self.mem_upper);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts lower memory from kilobytes to bytes and return it.
+    ///
+    pub fn mem_lower_tobytes(&self) -> Result<usize, Error> {
+        Ok(*self.mem_lower * 1024)
+    }
+}

--- a/src/hal/platform/pc/mboot/basic_mem_info.rs
+++ b/src/hal/platform/pc/mboot/basic_mem_info.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::hal::platform::mboot::MbootTagType;
 use ::sys::error::{
     Error,
     ErrorCode,
@@ -22,7 +23,7 @@ use ::sys::error::{
 #[repr(C, align(8))]
 pub struct MbootBasicMeminfoTag {
     /// Type.
-    typ: u32,
+    typ: MbootTagType,
     /// Size.
     size: u32,
 }

--- a/src/hal/platform/pc/mboot/mboot_tag.rs
+++ b/src/hal/platform/pc/mboot/mboot_tag.rs
@@ -1,0 +1,63 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Multiboot Tag Type
+//==================================================================================================
+
+#[repr(u16)]
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum MbootTagType {
+    End = 0,
+    Cmdline = 1,
+    BootLoaderName = 2,
+    Module = 3,
+    BasicMeminfo = 4,
+    Bootdev = 5,
+    Mmap = 6,
+    Vbe = 7,
+    Framebuffer = 8,
+    ElfSections = 9,
+    Apm = 10,
+    Efi32 = 11,
+    Efi64 = 12,
+    Smbios = 13,
+    AcpiOld = 14,
+    AcpiNew = 15,
+    Network = 16,
+    EfiMmap = 17,
+    EfiBs = 18,
+    Efi32Ih = 19,
+    Efi64Ih = 20,
+    LoadBaseAddr = 21,
+}
+
+impl From<u16> for MbootTagType {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => MbootTagType::End,
+            1 => MbootTagType::Cmdline,
+            2 => MbootTagType::BootLoaderName,
+            3 => MbootTagType::Module,
+            4 => MbootTagType::BasicMeminfo,
+            5 => MbootTagType::Bootdev,
+            6 => MbootTagType::Mmap,
+            7 => MbootTagType::Vbe,
+            8 => MbootTagType::Framebuffer,
+            9 => MbootTagType::ElfSections,
+            10 => MbootTagType::Apm,
+            11 => MbootTagType::Efi32,
+            12 => MbootTagType::Efi64,
+            13 => MbootTagType::Smbios,
+            14 => MbootTagType::AcpiOld,
+            15 => MbootTagType::AcpiNew,
+            16 => MbootTagType::Network,
+            17 => MbootTagType::EfiMmap,
+            18 => MbootTagType::EfiBs,
+            19 => MbootTagType::Efi32Ih,
+            20 => MbootTagType::Efi64Ih,
+            21 => MbootTagType::LoadBaseAddr,
+            _ => panic!("invalid multiboot tag type {}", value),
+        }
+    }
+}

--- a/src/hal/platform/pc/mboot/memory_map.rs
+++ b/src/hal/platform/pc/mboot/memory_map.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::hal::platform::mboot::MbootTagType;
 use crate::hal::mem::MemoryRegionType;
 use ::core::mem;
 use ::sys::error::{
@@ -26,7 +27,7 @@ pub enum MbootMemoryType {
     Available = 1,
     /// Reserved.
     Reserved = 2,
-    /// ACPI reclaimable.
+   /// ACPI reclaimable.
     AcpiReclaimable = 3,
     /// NVS.
     Nvs = 4,
@@ -151,7 +152,7 @@ impl core::fmt::Debug for MbootMemoryMapEntry {
 #[repr(C, align(8))]
 struct MbootMemoryMapTag {
     /// Type.
-    typ: u32,
+    typ: MbootTagType,
     /// Total size including the header.
     size: u32,
     /// Size of each entry.

--- a/src/hal/platform/pc/mboot/module.rs
+++ b/src/hal/platform/pc/mboot/module.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::hal::platform::mboot::MbootTagType;
 use ::core::{
     ffi::CStr,
     mem,
@@ -26,7 +27,7 @@ use ::sys::error::{
 #[repr(C, align(8))]
 pub struct MbootModuleTag {
     /// Type.
-    typ: u32,
+    typ: MbootTagType,
     /// Size.
     size: u32,
     /// Start.
@@ -45,7 +46,7 @@ impl core::fmt::Debug for MbootModuleTag {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
-            "mboot_module_tag: typ={:#010x}, size={}, start={:#010x}, end={:#010x}",
+            "mboot_module_tag: typ={:?}, size={}, start={:#010x}, end={:#010x}",
             self.typ, self.size, self.start, self.end
         )
     }


### PR DESCRIPTION
## Description
Parse the multiboot tag [Basic Memory Information](https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html#Basic-memory-information), to get the `mem_lower` entrie that store the size of the available lower physical memory region starting of the address 0x0. So, ensure that the hardcode memory regions are available for use. This closes #435 

## Files Changed

- src/hal/mod.rs
- src/hal/platform/bootinfo.rs
- src/hal/platform/microvm.rs
- src/hal/platform/pc/mboot/mod.rs
- src/hal/platform/pc/mod.rs
- src/kmain.rs

## File Created

- src/hal/platform/pc/mboot/basic_mem_info.rs
