### PR TITLE
[contrib] No Default Features for `arch`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,7 @@ name = "kernel"
 path = "src/kmain.rs"
 
 [dependencies]
-arch = { git = "https://github.com/nanvix/arch", branch = "releases/v1.3.1", features = [
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
-    "xapic",
-] }
+arch = { git = "https://github.com/nanvix/arch", branch = "releases/v1.3.1", default-features = false }
 cfg-if = "1.0.0"
 
 [build-dependencies]
@@ -38,8 +30,30 @@ cfg-if = "1.0.0"
 default = ["qemu-pc"]
 
 # Machine Types
-microvm = ["stdio"]
-pc = ["bios", "cmos", "mboot", "pit", "warn"]
+microvm = [
+    "stdio",
+    "arch/acpi",
+    "arch/cpuid",
+    "arch/ioapic",
+    "arch/madt",
+    "arch/msr",
+    "arch/pic",
+    "arch/xapic",
+]
+pc = [
+    "bios",
+    "cmos",
+    "mboot",
+    "pit",
+    "warn",
+    "arch/acpi",
+    "arch/cpuid",
+    "arch/ioapic",
+    "arch/madt",
+    "arch/msr",
+    "arch/pic",
+    "arch/xapic",
+]
 qemu-pc = ["pc"]
 qemu-pc-smp = ["qemu-pc", "smp"]
 qemu-baremetal = ["pc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kernel"
-version = "0.7.0"
+version = "0.7.1"
 license-file = "LICENSE.txt"
 edition = "2021"
 authors = ["The Maintainers of Nanvix"]


### PR DESCRIPTION
## Description

- Do not rely on default features for `arch`.