### PR TITLE
[pm] Thottle IKC Messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kernel"
-version = "0.7.2"
+version = "0.7.3"
 license-file = "LICENSE.txt"
 edition = "2021"
 authors = ["The Maintainers of Nanvix"]

--- a/src/sys/config.rs
+++ b/src/sys/config.rs
@@ -68,6 +68,18 @@ pub mod kernel {
     /// - This should be a power of two.
     ///
     pub const SCHEDULER_FREQ: usize = 128;
+
+    ///
+    /// # Description
+    ///
+    /// Maximum number of messages that can be buffered by the kernel.
+    ///
+    /// # Notes
+    ///
+    /// - When this threshold is reached, inter-kernel communication is blocked.
+    /// - This value should be set according to the amount of memory available in the kernel heap.
+    ///
+    pub const MAX_IKC_MESSAGES: usize = 128;
 }
 
 //==================================================================================================


### PR DESCRIPTION
## Description

This PR introduces a simple throttling heuristic for IKC messages to prevent the kernel from running out of memory under heavy load.