### PR TITLE
[build] Gate `kcall` Behind Target OS

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -24,7 +24,7 @@ pub mod event;
 pub mod ipc;
 
 /// Kernel calls.
-#[cfg(feature = "kcall")]
+#[cfg(all(target_os = "none", feature = "kcall"))]
 pub mod kcall;
 
 /// Helper macros.


### PR DESCRIPTION
## Description

This PR gates `kcall` module behind the `target_os` feature. This enales kernel library to use in hosted environments.