### PR TITLE
[pm] Renaming `PROCD` to `INITD`

### DIFF
--- a/src/kcall/handler.rs
+++ b/src/kcall/handler.rs
@@ -139,8 +139,8 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager, pm: &mut Process
         match pm.harvest_zombies() {
             Ok(None) => {},
             Ok(Some((pid, status))) => {
-                // Check if process daemon was terminated.
-                if pid == ProcessIdentifier::PROCD {
+                // Check if init daemon process terminated.
+                if pid == ProcessIdentifier::INITD {
                     // It was, so we should shutdown.
                     break;
                 }

--- a/src/sys/pm/pid.rs
+++ b/src/sys/pm/pid.rs
@@ -32,8 +32,8 @@ impl ProcessIdentifier {
     /// Identifier of the kernel process.
     pub const KERNEL: ProcessIdentifier = ProcessIdentifier(0);
 
-    /// Identifier of the process manager daemon process.
-    pub const PROCD: ProcessIdentifier = ProcessIdentifier(1);
+    /// Identifier of the init daemon process.
+    pub const INITD: ProcessIdentifier = ProcessIdentifier(1);
 
     pub fn to_ne_bytes(&self) -> [u8; core::mem::size_of::<u32>()] {
         self.0.to_ne_bytes()


### PR DESCRIPTION
## Description

This PR renames the special identifier of the very first user-level process from `PROCD` to `INITD`.

The kernel does not rely on the assumption that the very-first user-level process is running a process daemon, thus the special identifier should not be named so.