### PR TITLE
[config] Move `IPC_MESSAGE_SIZE` to Kernel Configuration Module

### DIFF
--- a/src/sys/config.rs
+++ b/src/sys/config.rs
@@ -91,7 +91,7 @@ pub mod kernel {
     /// - The value of this function has direct impact on IPC performance.
     /// - The default value is set to match the size of a cache line in x86 processors.
     ///
-    pub const TOTAL_SIZE: usize = 64;
+    pub const IPC_MESSAGE_SIZE: usize = 64;
 }
 
 //==================================================================================================

--- a/src/sys/config.rs
+++ b/src/sys/config.rs
@@ -80,6 +80,18 @@ pub mod kernel {
     /// - This value should be set according to the amount of memory available in the kernel heap.
     ///
     pub const MAX_IKC_MESSAGES: usize = 128;
+
+    ///
+    /// # Description
+    ///
+    /// Size of an IPC message.
+    ///
+    /// # Notes
+    ///
+    /// - The value of this function has direct impact on IPC performance.
+    /// - The default value is set to match the size of a cache line in x86 processors.
+    ///
+    pub const TOTAL_SIZE: usize = 64;
 }
 
 //==================================================================================================

--- a/src/sys/ipc/message.rs
+++ b/src/sys/ipc/message.rs
@@ -43,7 +43,7 @@ pub struct Message {
     /// Payload of the message.
     pub payload: [u8; Self::PAYLOAD_SIZE],
 }
-crate::static_assert_size!(Message, config::kernel::TOTAL_SIZE);
+crate::static_assert_size!(Message, config::kernel::IPC_MESSAGE_SIZE);
 
 //==================================================================================================
 //  Implementations
@@ -54,7 +54,7 @@ impl Message {
     pub const HEADER_SIZE: usize =
         2 * mem::size_of::<ProcessIdentifier>() + MessageType::SIZE + mem::size_of::<i32>();
     /// The size of the message's payload.
-    pub const PAYLOAD_SIZE: usize = config::kernel::TOTAL_SIZE - Self::HEADER_SIZE;
+    pub const PAYLOAD_SIZE: usize = config::kernel::IPC_MESSAGE_SIZE - Self::HEADER_SIZE;
 
     ///
     /// # Description

--- a/src/sys/ipc/message.rs
+++ b/src/sys/ipc/message.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     ipc::typ::MessageType,
     pm::ProcessIdentifier,
+    sys::config,
 };
 use ::core::mem;
 
@@ -42,20 +43,18 @@ pub struct Message {
     /// Payload of the message.
     pub payload: [u8; Self::PAYLOAD_SIZE],
 }
-crate::static_assert_size!(Message, Message::TOTAL_SIZE);
+crate::static_assert_size!(Message, config::kernel::TOTAL_SIZE);
 
 //==================================================================================================
 //  Implementations
 //==================================================================================================
 
 impl Message {
-    /// Total Size of a message.
-    pub const TOTAL_SIZE: usize = 64;
     /// The size of the message header fields (source, destination and type).
     pub const HEADER_SIZE: usize =
         2 * mem::size_of::<ProcessIdentifier>() + MessageType::SIZE + mem::size_of::<i32>();
     /// The size of the message's payload.
-    pub const PAYLOAD_SIZE: usize = Self::TOTAL_SIZE - Self::HEADER_SIZE;
+    pub const PAYLOAD_SIZE: usize = config::kernel::TOTAL_SIZE - Self::HEADER_SIZE;
 
     ///
     /// # Description


### PR DESCRIPTION
## Description

This PR adds the following changes:

- Rename `TOTAL_SIZE` to `IPC_MESSAGE_SIZE`
- Move `IPC_MESSAGE_SIZE` to kernel configuration module.