### PR TITLE
Enable Copy from User Space Spanning Across Pages[mm] 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kernel"
-version = "1.1.1"
+version = "1.1.2"
 license-file = "LICENSE.txt"
 edition = "2021"
 authors = ["The Maintainers of Nanvix"]

--- a/src/mm/virt/vmem.rs
+++ b/src/mm/virt/vmem.rs
@@ -435,12 +435,13 @@ impl Vmem {
             fn __physcopy(dst: *mut u8, src: *const u8, size: usize);
         }
 
-        // Check if source address does not lie in user space.
-        if !Self::is_user_addr(src) {
-            let reason: &str = "source address does not lie in user space";
+        // Check if size is invalid.
+        if size == 0 {
+            let reason: &str = "zero-length copy";
             error!("copy_from_user_unaligned(): {}", reason);
-            return Err(Error::new(ErrorCode::BadAddress, reason));
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
+
 
         // Check if destination address does not lie in kernel space.
         if !Self::is_kernel_addr(dst) {

--- a/src/mm/virt/vmem.rs
+++ b/src/mm/virt/vmem.rs
@@ -425,6 +425,23 @@ impl Vmem {
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 
+    ///
+    /// # Description
+    ///
+    /// Copies data from user space to kernel space. The source and destination addresses do not
+    /// have to be aligned, but the source address range must lie in user space, and the destination
+    /// address range must lie in kernel space.
+    ///
+    /// # Parameters
+    ///
+    /// - `dst`: Destination address in kernel space.
+    /// - `src`: Source address in user space.
+    /// - `size`: Number of bytes to copy.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Upon failure, an error code is returned instead.
+    ///
     pub fn copy_from_user_unaligned(
         &self,
         dst: VirtualAddress,


### PR DESCRIPTION
## Description

This PR closes https://github.com/nanvix/kernel/issues/457

This PR introduces the following changes:
- Check for zero-length copies.
- Enable copies spanning acros page boundaries.
- Check end address of copies
 